### PR TITLE
Added support for 10.0.22621.2860

### DIFF
--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -3,7 +3,7 @@
 ; Edited by bobo && sebaxakerhtc
 
 [Main]
-Updated=2024-03-30
+Updated=2024-03-31
 LogFile=\rdpwrap.txt
 SLPolicyHookNT60=1
 SLPolicyHookNT61=1
@@ -7606,6 +7606,20 @@ SLInitHook.x64=1
 SLInitOffset.x64=295A0
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.22621.2860]
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=9D1A1
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=18612
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=1C055
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x64=1
+SLInitOffset.x64=29570
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.22621.2861]
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=9D1A1
@@ -14115,6 +14129,16 @@ ulMaxDebugSessions.x64=12AF70
 bFUSEnabled.x64       =12AF74
 
 [10.0.22621.2706-SLInit]
+bInitialized.x64      =12AF4C
+bServerSku.x64        =12AF50
+lMaxUserSessions.x64  =12AF54
+bAppServerAllowed.x64 =12AF5C
+bRemoteConnAllowed.x64=12AF64
+bMultimonAllowed.x64  =12AF68
+ulMaxDebugSessions.x64=12AF70
+bFUSEnabled.x64       =12AF74
+
+[10.0.22621.2860-SLInit]
 bInitialized.x64      =12AF4C
 bServerSku.x64        =12AF50
 lMaxUserSessions.x64  =12AF54


### PR DESCRIPTION
Seems to be a perfect copy of 10.0.22621.2861, but we need an entry so the supported check works.